### PR TITLE
5 unit test coredatamanager 단위테스트

### DIFF
--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		AC52BAEB2988D3DC0057CA56 /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAC729880B770057CA56 /* CoreDataError.swift */; };
 		AC52BAEC2988D3E10057CA56 /* MeasureData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAAB2987E9930057CA56 /* MeasureData.swift */; };
 		AC52BAED2988D3E30057CA56 /* Sensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAAF2987E9D10057CA56 /* Sensor.swift */; };
+		AC52BAF92988E7AC0057CA56 /* CoreDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */; };
+		AC52BAFA2988E7AC0057CA56 /* CoreDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +71,7 @@
 		AC52BADF2988D3410057CA56 /* CoreDataManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManagerMock.swift; sourceTree = "<group>"; };
 		AC52BAE12988D35C0057CA56 /* FileSystemManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemManagerMock.swift; sourceTree = "<group>"; };
 		AC52BAE42988D3C30057CA56 /* FileSystemManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemManagerTests.swift; sourceTree = "<group>"; };
+		AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataRepository.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +123,7 @@
 		AC52BAA82987E8F80057CA56 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				AC52BAF62988E7800057CA56 /* Interfaces */,
 				AC52BAAA2987E9380057CA56 /* Entities */,
 				AC52BAAD2987E9C60057CA56 /* TransactionService.swift */,
 			);
@@ -245,6 +249,22 @@
 			path = Application;
 			sourceTree = "<group>";
 		};
+		AC52BAF62988E7800057CA56 /* Interfaces */ = {
+			isa = PBXGroup;
+			children = (
+				AC52BAF72988E78A0057CA56 /* Repositories */,
+			);
+			path = Interfaces;
+			sourceTree = "<group>";
+		};
+		AC52BAF72988E78A0057CA56 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -352,6 +372,7 @@
 				63F01BB728D44FC400C53A39 /* SceneDelegate.swift in Sources */,
 				AC52BAC52987F91A0057CA56 /* SensorData+CoreDataProperties.swift in Sources */,
 				AC52BAAE2987E9C60057CA56 /* TransactionService.swift in Sources */,
+				AC52BAF92988E7AC0057CA56 /* CoreDataRepository.swift in Sources */,
 				AC52BAC42987F91A0057CA56 /* SensorData+CoreDataClass.swift in Sources */,
 				AC52BAB22987EA180057CA56 /* CoreDataManager.swift in Sources */,
 				AC52BAAC2987E9930057CA56 /* MeasureData.swift in Sources */,
@@ -368,6 +389,7 @@
 			files = (
 				AC52BAE72988D3CC0057CA56 /* CoreDataManager.swift in Sources */,
 				AC52BAED2988D3E30057CA56 /* Sensor.swift in Sources */,
+				AC52BAFA2988E7AC0057CA56 /* CoreDataRepository.swift in Sources */,
 				AC52BAEA2988D3DA0057CA56 /* FileSystemError.swift in Sources */,
 				AC52BAEC2988D3E10057CA56 /* MeasureData.swift in Sources */,
 				AC52BAE62988D3C90057CA56 /* FileSystemManager.swift in Sources */,

--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -18,8 +18,6 @@
 		AC52BAB22987EA180057CA56 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAB12987EA180057CA56 /* CoreDataManager.swift */; };
 		AC52BAB42987EA2A0057CA56 /* FileSystemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAB32987EA2A0057CA56 /* FileSystemManager.swift */; };
 		AC52BAC12987F8BA0057CA56 /* SensorData.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = AC52BABF2987F8BA0057CA56 /* SensorData.xcdatamodeld */; };
-		AC52BAC42987F91A0057CA56 /* SensorData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAC22987F91A0057CA56 /* SensorData+CoreDataClass.swift */; };
-		AC52BAC52987F91A0057CA56 /* SensorData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAC32987F91A0057CA56 /* SensorData+CoreDataProperties.swift */; };
 		AC52BAC829880B770057CA56 /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAC729880B770057CA56 /* CoreDataError.swift */; };
 		AC52BACB2988D1440057CA56 /* FileSystemError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BACA2988D1440057CA56 /* FileSystemError.swift */; };
 		AC52BADB2988D29A0057CA56 /* CoreDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BADA2988D29A0057CA56 /* CoreDataManagerTests.swift */; };
@@ -27,8 +25,6 @@
 		AC52BAE22988D35C0057CA56 /* FileSystemManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAE12988D35C0057CA56 /* FileSystemManagerMock.swift */; };
 		AC52BAE62988D3C90057CA56 /* FileSystemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAB32987EA2A0057CA56 /* FileSystemManager.swift */; };
 		AC52BAE72988D3CC0057CA56 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAB12987EA180057CA56 /* CoreDataManager.swift */; };
-		AC52BAE82988D3D50057CA56 /* SensorData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAC22987F91A0057CA56 /* SensorData+CoreDataClass.swift */; };
-		AC52BAE92988D3D70057CA56 /* SensorData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAC32987F91A0057CA56 /* SensorData+CoreDataProperties.swift */; };
 		AC52BAEA2988D3DA0057CA56 /* FileSystemError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BACA2988D1440057CA56 /* FileSystemError.swift */; };
 		AC52BAEB2988D3DC0057CA56 /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAC729880B770057CA56 /* CoreDataError.swift */; };
 		AC52BAEC2988D3E10057CA56 /* MeasureData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAAB2987E9930057CA56 /* MeasureData.swift */; };
@@ -37,6 +33,11 @@
 		AC52BAFA2988E7AC0057CA56 /* CoreDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */; };
 		AC52BAFD2988EF900057CA56 /* MeasureDataDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAFC2988EF900057CA56 /* MeasureDataDummy.swift */; };
 		AC52BAFF2988F1EC0057CA56 /* FileSystemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAFE2988F1EC0057CA56 /* FileSystemManagerTests.swift */; };
+		AC52BB2429890A6E0057CA56 /* SensorData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB2229890A6E0057CA56 /* SensorData+CoreDataClass.swift */; };
+		AC52BB2529890A6E0057CA56 /* SensorData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB2229890A6E0057CA56 /* SensorData+CoreDataClass.swift */; };
+		AC52BB2629890A6E0057CA56 /* SensorData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB2329890A6E0057CA56 /* SensorData+CoreDataProperties.swift */; };
+		AC52BB2929890B2E0057CA56 /* SensorData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB2329890A6E0057CA56 /* SensorData+CoreDataProperties.swift */; };
+		AC52BB2A29890C9F0057CA56 /* SensorData.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = AC52BABF2987F8BA0057CA56 /* SensorData.xcdatamodeld */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,8 +64,6 @@
 		AC52BAB12987EA180057CA56 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		AC52BAB32987EA2A0057CA56 /* FileSystemManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemManager.swift; sourceTree = "<group>"; };
 		AC52BAC02987F8BA0057CA56 /* SensorData.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SensorData.xcdatamodel; sourceTree = "<group>"; };
-		AC52BAC22987F91A0057CA56 /* SensorData+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SensorData+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
-		AC52BAC32987F91A0057CA56 /* SensorData+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SensorData+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
 		AC52BAC729880B770057CA56 /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
 		AC52BACA2988D1440057CA56 /* FileSystemError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileSystemError.swift; sourceTree = "<group>"; };
 		AC52BAD02988D2540057CA56 /* GyroDataTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GyroDataTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -74,6 +73,8 @@
 		AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataRepository.swift; sourceTree = "<group>"; };
 		AC52BAFC2988EF900057CA56 /* MeasureDataDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureDataDummy.swift; sourceTree = "<group>"; };
 		AC52BAFE2988F1EC0057CA56 /* FileSystemManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemManagerTests.swift; sourceTree = "<group>"; };
+		AC52BB2229890A6E0057CA56 /* SensorData+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SensorData+CoreDataClass.swift"; sourceTree = "<group>"; };
+		AC52BB2329890A6E0057CA56 /* SensorData+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SensorData+CoreDataProperties.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -154,8 +155,8 @@
 		AC52BABE2987F8A10057CA56 /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
-				AC52BAC22987F91A0057CA56 /* SensorData+CoreDataClass.swift */,
-				AC52BAC32987F91A0057CA56 /* SensorData+CoreDataProperties.swift */,
+				AC52BB2229890A6E0057CA56 /* SensorData+CoreDataClass.swift */,
+				AC52BB2329890A6E0057CA56 /* SensorData+CoreDataProperties.swift */,
 				AC52BABF2987F8BA0057CA56 /* SensorData.xcdatamodeld */,
 			);
 			path = CoreData;
@@ -381,14 +382,14 @@
 				AC52BAB02987E9D10057CA56 /* Sensor.swift in Sources */,
 				63F01BB528D44FC400C53A39 /* AppDelegate.swift in Sources */,
 				63F01BB728D44FC400C53A39 /* SceneDelegate.swift in Sources */,
-				AC52BAC52987F91A0057CA56 /* SensorData+CoreDataProperties.swift in Sources */,
 				AC52BAAE2987E9C60057CA56 /* TransactionService.swift in Sources */,
 				AC52BAF92988E7AC0057CA56 /* CoreDataRepository.swift in Sources */,
-				AC52BAC42987F91A0057CA56 /* SensorData+CoreDataClass.swift in Sources */,
+				AC52BB2429890A6E0057CA56 /* SensorData+CoreDataClass.swift in Sources */,
 				AC52BAB22987EA180057CA56 /* CoreDataManager.swift in Sources */,
 				AC52BAAC2987E9930057CA56 /* MeasureData.swift in Sources */,
 				AC52BAB42987EA2A0057CA56 /* FileSystemManager.swift in Sources */,
 				AC52BAC12987F8BA0057CA56 /* SensorData.xcdatamodeld in Sources */,
+				AC52BB2629890A6E0057CA56 /* SensorData+CoreDataProperties.swift in Sources */,
 				AC52BAC829880B770057CA56 /* CoreDataError.swift in Sources */,
 				AC52BACB2988D1440057CA56 /* FileSystemError.swift in Sources */,
 			);
@@ -404,14 +405,15 @@
 				AC52BAEA2988D3DA0057CA56 /* FileSystemError.swift in Sources */,
 				AC52BAEC2988D3E10057CA56 /* MeasureData.swift in Sources */,
 				AC52BAFD2988EF900057CA56 /* MeasureDataDummy.swift in Sources */,
+				AC52BB2529890A6E0057CA56 /* SensorData+CoreDataClass.swift in Sources */,
 				AC52BAE62988D3C90057CA56 /* FileSystemManager.swift in Sources */,
 				AC52BAE02988D3410057CA56 /* CoreDataManagerMock.swift in Sources */,
+				AC52BB2929890B2E0057CA56 /* SensorData+CoreDataProperties.swift in Sources */,
 				AC52BADB2988D29A0057CA56 /* CoreDataManagerTests.swift in Sources */,
-				AC52BAE82988D3D50057CA56 /* SensorData+CoreDataClass.swift in Sources */,
 				AC52BAFF2988F1EC0057CA56 /* FileSystemManagerTests.swift in Sources */,
-				AC52BAE92988D3D70057CA56 /* SensorData+CoreDataProperties.swift in Sources */,
 				AC52BAEB2988D3DC0057CA56 /* CoreDataError.swift in Sources */,
 				AC52BAE22988D35C0057CA56 /* FileSystemManagerMock.swift in Sources */,
+				AC52BB2A29890C9F0057CA56 /* SensorData.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		AC52BADB2988D29A0057CA56 /* CoreDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BADA2988D29A0057CA56 /* CoreDataManagerTests.swift */; };
 		AC52BAE02988D3410057CA56 /* CoreDataManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BADF2988D3410057CA56 /* CoreDataManagerMock.swift */; };
 		AC52BAE22988D35C0057CA56 /* FileSystemManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAE12988D35C0057CA56 /* FileSystemManagerMock.swift */; };
-		AC52BAE52988D3C30057CA56 /* FileSystemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAE42988D3C30057CA56 /* FileSystemManagerTests.swift */; };
 		AC52BAE62988D3C90057CA56 /* FileSystemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAB32987EA2A0057CA56 /* FileSystemManager.swift */; };
 		AC52BAE72988D3CC0057CA56 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAB12987EA180057CA56 /* CoreDataManager.swift */; };
 		AC52BAE82988D3D50057CA56 /* SensorData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAC22987F91A0057CA56 /* SensorData+CoreDataClass.swift */; };
@@ -36,6 +35,8 @@
 		AC52BAED2988D3E30057CA56 /* Sensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAAF2987E9D10057CA56 /* Sensor.swift */; };
 		AC52BAF92988E7AC0057CA56 /* CoreDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */; };
 		AC52BAFA2988E7AC0057CA56 /* CoreDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */; };
+		AC52BAFD2988EF900057CA56 /* MeasureDataDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAFC2988EF900057CA56 /* MeasureDataDummy.swift */; };
+		AC52BAFF2988F1EC0057CA56 /* FileSystemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BAFE2988F1EC0057CA56 /* FileSystemManagerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,8 +71,9 @@
 		AC52BADA2988D29A0057CA56 /* CoreDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManagerTests.swift; sourceTree = "<group>"; };
 		AC52BADF2988D3410057CA56 /* CoreDataManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManagerMock.swift; sourceTree = "<group>"; };
 		AC52BAE12988D35C0057CA56 /* FileSystemManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemManagerMock.swift; sourceTree = "<group>"; };
-		AC52BAE42988D3C30057CA56 /* FileSystemManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemManagerTests.swift; sourceTree = "<group>"; };
 		AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataRepository.swift; sourceTree = "<group>"; };
+		AC52BAFC2988EF900057CA56 /* MeasureDataDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureDataDummy.swift; sourceTree = "<group>"; };
+		AC52BAFE2988F1EC0057CA56 /* FileSystemManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemManagerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -188,6 +190,7 @@
 		AC52BADD2988D2D40057CA56 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				AC52BAFB2988EF260057CA56 /* Dummy */,
 				AC52BADE2988D2D90057CA56 /* Mock */,
 			);
 			path = Common;
@@ -205,7 +208,7 @@
 		AC52BAE32988D3630057CA56 /* FileSystemManagerTests */ = {
 			isa = PBXGroup;
 			children = (
-				AC52BAE42988D3C30057CA56 /* FileSystemManagerTests.swift */,
+				AC52BAFE2988F1EC0057CA56 /* FileSystemManagerTests.swift */,
 			);
 			path = FileSystemManagerTests;
 			sourceTree = "<group>";
@@ -263,6 +266,14 @@
 				AC52BAF82988E7AC0057CA56 /* CoreDataRepository.swift */,
 			);
 			path = Repositories;
+			sourceTree = "<group>";
+		};
+		AC52BAFB2988EF260057CA56 /* Dummy */ = {
+			isa = PBXGroup;
+			children = (
+				AC52BAFC2988EF900057CA56 /* MeasureDataDummy.swift */,
+			);
+			path = Dummy;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -392,13 +403,14 @@
 				AC52BAFA2988E7AC0057CA56 /* CoreDataRepository.swift in Sources */,
 				AC52BAEA2988D3DA0057CA56 /* FileSystemError.swift in Sources */,
 				AC52BAEC2988D3E10057CA56 /* MeasureData.swift in Sources */,
+				AC52BAFD2988EF900057CA56 /* MeasureDataDummy.swift in Sources */,
 				AC52BAE62988D3C90057CA56 /* FileSystemManager.swift in Sources */,
 				AC52BAE02988D3410057CA56 /* CoreDataManagerMock.swift in Sources */,
 				AC52BADB2988D29A0057CA56 /* CoreDataManagerTests.swift in Sources */,
 				AC52BAE82988D3D50057CA56 /* SensorData+CoreDataClass.swift in Sources */,
+				AC52BAFF2988F1EC0057CA56 /* FileSystemManagerTests.swift in Sources */,
 				AC52BAE92988D3D70057CA56 /* SensorData+CoreDataProperties.swift in Sources */,
 				AC52BAEB2988D3DC0057CA56 /* CoreDataError.swift in Sources */,
-				AC52BAE52988D3C30057CA56 /* FileSystemManagerTests.swift in Sources */,
 				AC52BAE22988D35C0057CA56 /* FileSystemManagerMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -612,7 +624,7 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "GyroDataTests/GyroDataTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -641,7 +653,7 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "GyroDataTests/GyroDataTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GyroData.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/GyroData";

--- a/GyroData/Source/Data/CoreData/SensorData+CoreDataClass.swift
+++ b/GyroData/Source/Data/CoreData/SensorData+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  SensorData+CoreDataClass.swift
 //  GyroData
 //
-//  Created by 이정민 on 2023/01/30.
+//  Created by 이정민 on 2023/01/31.
 //
 //
 

--- a/GyroData/Source/Data/CoreData/SensorData+CoreDataProperties.swift
+++ b/GyroData/Source/Data/CoreData/SensorData+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  SensorData+CoreDataProperties.swift
 //  GyroData
 //
-//  Created by 이정민 on 2023/01/30.
+//  Created by 이정민 on 2023/01/31.
 //
 //
 
@@ -16,12 +16,12 @@ extension SensorData {
         return NSFetchRequest<SensorData>(entityName: "SensorData")
     }
 
+    @NSManaged public var date: Date
+    @NSManaged public var runTime: Double
+    @NSManaged public var type: Int16
     @NSManaged public var xValue: [Double]
     @NSManaged public var yValue: [Double]
     @NSManaged public var zValue: [Double]
-    @NSManaged public var type: Int16
-    @NSManaged public var runTime: Double
-    @NSManaged public var date: Date
 
 }
 

--- a/GyroData/Source/Data/CoreData/SensorData.xcdatamodeld/SensorData.xcdatamodel/contents
+++ b/GyroData/Source/Data/CoreData/SensorData.xcdatamodeld/SensorData.xcdatamodel/contents
@@ -4,8 +4,8 @@
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="runTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="xValue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="yValue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="zValue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="xValue" optional="YES" attributeType="Transformable"/>
+        <attribute name="yValue" optional="YES" attributeType="Transformable"/>
+        <attribute name="zValue" optional="YES" attributeType="Transformable"/>
     </entity>
 </model>

--- a/GyroData/Source/Data/CoreDataManager.swift
+++ b/GyroData/Source/Data/CoreDataManager.swift
@@ -43,7 +43,7 @@ extension CoreDataManager {
         content.setValue(model.zValue, forKey: "zValue")
         content.setValue(model.date, forKey: "date")
         content.setValue(model.runTime, forKey: "runTime")
-        content.setValue(model.type, forKey: "type")
+        content.setValue(model.type?.rawValue, forKey: "type")
         
         do {
             try context.save()

--- a/GyroData/Source/Data/CoreDataManager.swift
+++ b/GyroData/Source/Data/CoreDataManager.swift
@@ -8,7 +8,7 @@
 import CoreData
 import Foundation
 
-final class CoreDataManager {
+final class CoreDataManager: CoreDataRepository {
     private let persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "SensorData")
         container.loadPersistentStores { _, error in
@@ -67,10 +67,10 @@ extension CoreDataManager {
         }
     }
     
-    func delete(_ model: MeasureData) throws {
+    func delete(_ date: Date) throws {
         let request = SensorData.fetchRequest()
         
-        request.predicate = NSPredicate(format: "date == %@", model.date as CVarArg)
+        request.predicate = NSPredicate(format: "date == %@", date as CVarArg)
         
         do {
             let result = try context.fetch(request)

--- a/GyroData/Source/Data/CoreDataManager.swift
+++ b/GyroData/Source/Data/CoreDataManager.swift
@@ -36,14 +36,15 @@ final class CoreDataManager: CoreDataRepository {
 
 extension CoreDataManager {
     func save(_ model: MeasureData) throws {
+        guard let type = model.type?.rawValue else { throw CoreDataError.invalidData }
         let content = SensorData(context: self.context)
         
-        content.setValue(model.xValue, forKey: "xValue")
-        content.setValue(model.yValue, forKey: "yValue")
-        content.setValue(model.zValue, forKey: "zValue")
-        content.setValue(model.date, forKey: "date")
-        content.setValue(model.runTime, forKey: "runTime")
-        content.setValue(model.type?.rawValue, forKey: "type")
+        content.xValue = model.xValue
+        content.yValue = model.yValue
+        content.zValue = model.zValue
+        content.date = model.date
+        content.runTime = model.runTime
+        content.type = Int16(type)
         
         do {
             try context.save()

--- a/GyroData/Source/Domain/Entities/MeasureData.swift
+++ b/GyroData/Source/Domain/Entities/MeasureData.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 struct MeasureData: Encodable {
-    let xValue: Double
-    let yValue: Double
-    let zValue: Double
+    let xValue: [Double]
+    let yValue: [Double]
+    let zValue: [Double]
     let runTime: Double
     let date: Date
     let type: Sensor?

--- a/GyroData/Source/Domain/Interfaces/Repositories/CoreDataRepository.swift
+++ b/GyroData/Source/Domain/Interfaces/Repositories/CoreDataRepository.swift
@@ -1,0 +1,14 @@
+//
+//  CoreDataRepository.swift
+//  GyroData
+//
+//  Created by Kyo, JPush on 2023/01/31.
+//
+
+import Foundation
+
+protocol CoreDataRepository {
+    func save(_ model: MeasureData) throws
+    func fetch(offset: Int, limit: Int) throws -> [MeasureData]
+    func delete(_ date: Date) throws
+}

--- a/GyroDataTests/Common/Dummy/MeasureDataDummy.swift
+++ b/GyroDataTests/Common/Dummy/MeasureDataDummy.swift
@@ -1,0 +1,21 @@
+//
+//  MeasureDataDummy.swift
+//  GyroDataTests
+//
+//  Created by 이정민 on 2023/01/31.
+//
+
+import Foundation
+
+struct MeasureDataDummy {
+    static var dummys: [MeasureData] = [
+        MeasureData(
+            xValue: [15.2, 16.1, 23.4, 12.8],
+            yValue: [25.4, 40.1, 70.3, 55.5],
+            zValue: [45.1, 68.0, 73.3, 102.9],
+            runTime: 60,
+            date: Date(),
+            type: .accelerometer
+        )
+    ]
+}

--- a/GyroDataTests/Common/Mock/CoreDataManagerMock.swift
+++ b/GyroDataTests/Common/Mock/CoreDataManagerMock.swift
@@ -42,14 +42,15 @@ final class CoreDataManagerMock: CoreDataRepository {
 
 extension CoreDataManagerMock {
     func save(_ model: MeasureData) throws {
+        guard let type = model.type?.rawValue else { throw CoreDataError.invalidData }
         let content = SensorData(context: self.context)
         
-        content.setValue(model.xValue, forKey: "xValue")
-        content.setValue(model.yValue, forKey: "yValue")
-        content.setValue(model.zValue, forKey: "zValue")
-        content.setValue(model.date, forKey: "date")
-        content.setValue(model.runTime, forKey: "runTime")
-        content.setValue(model.type?.rawValue, forKey: "type")
+        content.xValue = model.xValue
+        content.yValue = model.yValue
+        content.zValue = model.zValue
+        content.date = model.date
+        content.runTime = model.runTime
+        content.type = Int16(type)
         
         do {
             try context.save()

--- a/GyroDataTests/Common/Mock/CoreDataManagerMock.swift
+++ b/GyroDataTests/Common/Mock/CoreDataManagerMock.swift
@@ -5,6 +5,7 @@
 //  Created by Kyo, JPush on 2023/01/31.
 //
 
+import CoreData
 import Foundation
 
 final class CoreDataManagerMock: CoreDataRepository {
@@ -48,7 +49,7 @@ extension CoreDataManagerMock {
         content.setValue(model.zValue, forKey: "zValue")
         content.setValue(model.date, forKey: "date")
         content.setValue(model.runTime, forKey: "runTime")
-        content.setValue(model.type, forKey: "type")
+        content.setValue(model.type?.rawValue, forKey: "type")
         
         do {
             try context.save()
@@ -75,7 +76,7 @@ extension CoreDataManagerMock {
     func delete(_ date: Date) throws {
         let request = SensorData.fetchRequest()
         
-        request.predicate = NSPredicate(format: "date == %@", model.date as CVarArg)
+        request.predicate = NSPredicate(format: "date == %@", date as CVarArg)
         
         do {
             let result = try context.fetch(request)

--- a/GyroDataTests/Common/Mock/CoreDataManagerMock.swift
+++ b/GyroDataTests/Common/Mock/CoreDataManagerMock.swift
@@ -6,3 +6,87 @@
 //
 
 import Foundation
+
+final class CoreDataManagerMock: CoreDataRepository {
+    private let persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "SensorData")
+        let description = NSPersistentStoreDescription()
+        
+        description.url = URL(fileURLWithPath: "/dev/null")
+        
+        container.persistentStoreDescriptions = [description]
+        container.loadPersistentStores { _, error in
+            if let error = error as NSError? {
+                print(error.localizedDescription)
+            }
+        }
+        return container
+    }()
+    
+    private lazy var context = persistentContainer.viewContext
+    
+    private func translateModel(from entity: SensorData) -> MeasureData {
+        let model = MeasureData(
+            xValue: entity.xValue,
+            yValue: entity.yValue,
+            zValue: entity.zValue,
+            runTime: entity.runTime,
+            date: entity.date,
+            type: Sensor(rawValue: Int(entity.type))
+        )
+        
+        return model
+    }
+}
+
+extension CoreDataManagerMock {
+    func save(_ model: MeasureData) throws {
+        let content = SensorData(context: self.context)
+        
+        content.setValue(model.xValue, forKey: "xValue")
+        content.setValue(model.yValue, forKey: "yValue")
+        content.setValue(model.zValue, forKey: "zValue")
+        content.setValue(model.date, forKey: "date")
+        content.setValue(model.runTime, forKey: "runTime")
+        content.setValue(model.type, forKey: "type")
+        
+        do {
+            try context.save()
+        } catch {
+            throw error
+        }
+    }
+    
+    func fetch(offset: Int, limit: Int) throws -> [MeasureData]  {
+        let request = SensorData.fetchRequest()
+        
+        request.fetchOffset = offset
+        request.fetchLimit = limit
+        
+        do {
+            let result = try context.fetch(request)
+            let models = result.map(translateModel)
+            return models
+        } catch {
+            throw error
+        }
+    }
+    
+    func delete(_ date: Date) throws {
+        let request = SensorData.fetchRequest()
+        
+        request.predicate = NSPredicate(format: "date == %@", model.date as CVarArg)
+        
+        do {
+            let result = try context.fetch(request)
+            guard let firstData = result.first else {
+                throw CoreDataError.invalidData
+            }
+            
+            context.delete(firstData)
+            try context.save()
+        } catch {
+            throw error
+        }
+    }
+}

--- a/GyroDataTests/CoreDataManagerTests/CoreDataManagerTests.swift
+++ b/GyroDataTests/CoreDataManagerTests/CoreDataManagerTests.swift
@@ -21,5 +21,9 @@ final class CoreDataManagerTests: XCTestCase {
         // then
         XCTAssertNoThrow(try coreDataManager?.save(measureData))
     }
-
+    
+    func test_fetch_seuccess() {
+        // then
+        XCTAssertNoThrow(try coreDataManager?.fetch(offset: 0, limit: 1))
+    }
 }

--- a/GyroDataTests/CoreDataManagerTests/CoreDataManagerTests.swift
+++ b/GyroDataTests/CoreDataManagerTests/CoreDataManagerTests.swift
@@ -22,8 +22,13 @@ final class CoreDataManagerTests: XCTestCase {
         XCTAssertNoThrow(try coreDataManager?.save(measureData))
     }
     
-    func test_fetch_seuccess() {
+    func test_fetch_success() {
         // then
         XCTAssertNoThrow(try coreDataManager?.fetch(offset: 0, limit: 1))
+    }
+    
+    func test_delete_failure_by_nowDate() {
+        // then
+        XCTAssertThrowsError(try coreDataManager?.delete(Date()))
     }
 }

--- a/GyroDataTests/CoreDataManagerTests/CoreDataManagerTests.swift
+++ b/GyroDataTests/CoreDataManagerTests/CoreDataManagerTests.swift
@@ -8,28 +8,18 @@
 import XCTest
 
 final class CoreDataManagerTests: XCTestCase {
-
+    var coreDataManager: CoreDataManagerMock?
+    
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        coreDataManager = CoreDataManagerMock()
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    func test_save_success() {
+        // given
+        let measureData = MeasureDataDummy.dummys[0]
+        
+        // then
+        XCTAssertNoThrow(try coreDataManager?.save(measureData))
     }
 
 }

--- a/GyroDataTests/FileSystemManagerTests/FileSystemManagerTests.swift
+++ b/GyroDataTests/FileSystemManagerTests/FileSystemManagerTests.swift
@@ -2,7 +2,34 @@
 //  FileSystemManagerTests.swift
 //  GyroDataTests
 //
-//  Created by Kyo, JPush on 2023/01/31.
+//  Created by 이정민 on 2023/01/31.
 //
 
-import Foundation
+import XCTest
+
+final class FileSystemManagerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/SensorData+CoreDataProperties.swift
+++ b/SensorData+CoreDataProperties.swift
@@ -16,9 +16,9 @@ extension SensorData {
         return NSFetchRequest<SensorData>(entityName: "SensorData")
     }
 
-    @NSManaged public var xValue: Double
-    @NSManaged public var yValue: Double
-    @NSManaged public var zValue: Double
+    @NSManaged public var xValue: [Double]
+    @NSManaged public var yValue: [Double]
+    @NSManaged public var zValue: [Double]
     @NSManaged public var type: Int16
     @NSManaged public var runTime: Double
     @NSManaged public var date: Date


### PR DESCRIPTION
#5 

#### 작업내용
- MeasureData의 x,y,z 값을 배열로 받도록 수정
- CoreDataManagerMock 생성
- CoreDataManagerDummy 생성
- save, fetch, delete 단위테스트

#### 참고사항
<img width="1505" alt="스크린샷 2023-01-31 18 37 35" src="https://user-images.githubusercontent.com/82566116/215725112-ebc46b5f-4d0c-42f9-9be5-f7dc1813db3c.png">

Dummy의 값을 넣어서 save, fetch, delete 테스트 하려 했으나 해결하지 못함.

데이터 모델의 문제인가 싶어 Double 타입 하나만 가지는 모델로 테스트 해보았으나 똑같은 결과.
Test가 아닌 실제 Container로 실행해보면 잘 반영됨.

실제 값을 넣지않고 행위테스트만 작업

- 재현코드
아래 코드로 대체시 재현 가능
```swift
func test_fetch_success() {
        let measureData = MeasureDataDummy.dummys[0]
        
        do {
            try coreDataManager?.save(measureData)
            let result = try coreDataManager?.fetch(offset: 0, limit: 1)
            print(result)
        } catch {
            print(error)
        }
    }
```

#### ✅필수체크
- [x] 테스트 통과
- [x] 정상적인 빌드