### PR TITLE
15 feature 센서 값 측정을 담당하는 객체 생성

### DIFF
--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		AC52BB4329895C5C0057CA56 /* MeasureDataDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB4229895C5C0057CA56 /* MeasureDataDummy.swift */; };
 		AC52BB45298967B50057CA56 /* Sensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB44298967B50057CA56 /* Sensor.swift */; };
 		AC52BB46298967B50057CA56 /* Sensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB44298967B50057CA56 /* Sensor.swift */; };
+		AC52BB48298A34070057CA56 /* SensorMeasureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB47298A34070057CA56 /* SensorMeasureService.swift */; };
+		AC52BB49298A34070057CA56 /* SensorMeasureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB47298A34070057CA56 /* SensorMeasureService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +86,7 @@
 		AC52BB3C298948E20057CA56 /* TransactionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionServiceTests.swift; sourceTree = "<group>"; };
 		AC52BB4229895C5C0057CA56 /* MeasureDataDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureDataDummy.swift; sourceTree = "<group>"; };
 		AC52BB44298967B50057CA56 /* Sensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sensor.swift; sourceTree = "<group>"; };
+		AC52BB47298A34070057CA56 /* SensorMeasureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMeasureService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -174,6 +177,7 @@
 				3CB15C4229893D9B0049E390 /* Protocol */,
 				AC52BAAA2987E9380057CA56 /* Entities */,
 				AC52BAAD2987E9C60057CA56 /* TransactionService.swift */,
+				AC52BB47298A34070057CA56 /* SensorMeasureService.swift */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -413,6 +417,7 @@
 				AC52BAAC2987E9930057CA56 /* MeasureData.swift in Sources */,
 				AC52BAB42987EA2A0057CA56 /* FileSystemManager.swift in Sources */,
 				3CB15C4A298945620049E390 /* DataListViewController.swift in Sources */,
+				AC52BB48298A34070057CA56 /* SensorMeasureService.swift in Sources */,
 				AC52BAC12987F8BA0057CA56 /* SensorData.xcdatamodeld in Sources */,
 				3CB15C4F298945D50049E390 /* MeasureViewController.swift in Sources */,
 				3CB15C51298945E40049E390 /* MeasureViewModel.swift in Sources */,
@@ -427,6 +432,7 @@
 			files = (
 				AC52BB4329895C5C0057CA56 /* MeasureDataDummy.swift in Sources */,
 				AC52BB46298967B50057CA56 /* Sensor.swift in Sources */,
+				AC52BB49298A34070057CA56 /* SensorMeasureService.swift in Sources */,
 				AC52BAE72988D3CC0057CA56 /* CoreDataManager.swift in Sources */,
 				AC52BB402989493D0057CA56 /* FileManageable.swift in Sources */,
 				AC52BAEA2988D3DA0057CA56 /* FileSystemError.swift in Sources */,

--- a/GyroData/Source/Domain/SensorMeasureService.swift
+++ b/GyroData/Source/Domain/SensorMeasureService.swift
@@ -83,6 +83,26 @@ private extension SensorMeasureService {
     }
     
     func gyroscopeMeasureStart(_ interval: TimeInterval, _ duration: TimeInterval) {
+        guard motionManager.isGyroAvailable else {
+            delegate?.nonGyroscopeMeasurable()
+            return
+        }
+        
         motionManager.gyroUpdateInterval = interval
+        motionManager.startGyroUpdates()
+        
+        timer = Timer(fire: Date(), interval: interval / duration, repeats: true) { timer in
+            if let data = self.motionManager.gyroData {
+                let gyroData = (data.rotationRate.x, data.rotationRate.y, data.rotationRate.z)
+                
+                self.data.append(gyroData)
+            }
+            
+            if self.isTimeOver(duration, from: timer.fireDate) {
+                timer.invalidate()
+            }
+        }
+        
+        RunLoop.current.add(timer, forMode: .common)
     }
 }

--- a/GyroData/Source/Domain/SensorMeasureService.swift
+++ b/GyroData/Source/Domain/SensorMeasureService.swift
@@ -15,6 +15,7 @@ protocol MeasureDelegate: AnyObject {
     func nonGyroscopeMeasurable()
     
     func updateData(_ data: [Values])
+    func endMeasuringData()
 }
 
 final class SensorMeasureService {
@@ -48,6 +49,7 @@ final class SensorMeasureService {
     
     func measureStop() {
         timer.invalidate()
+        delegate?.endMeasuringData()
     }
 }
 
@@ -67,11 +69,18 @@ private extension SensorMeasureService {
                 
                 self.data.append(accelerationData)
             }
+            
+            if self.isTimeOver(duration, from: timer.fireDate) {
+                timer.invalidate()
+            }
         }
         
         RunLoop.current.add(timer, forMode: .common)
     }
     
+    func isTimeOver(_ duration: TimeInterval, from fireDate: Date) -> Bool {
+        Date().timeIntervalSince(fireDate) > duration ? true : false
+    }
     
     func gyroscopeMeasureStart(_ interval: TimeInterval, _ duration: TimeInterval) {
         motionManager.gyroUpdateInterval = interval

--- a/GyroData/Source/Domain/SensorMeasureService.swift
+++ b/GyroData/Source/Domain/SensorMeasureService.swift
@@ -1,0 +1,16 @@
+//
+//  SensorMeasureService.swift
+//  GyroData
+//
+//  Created by 이정민 on 2023/02/01.
+//
+
+import Foundation
+protocol MeasureDelegate: AnyObject {
+    typealias Values = (x: Double, y: Double, z: Double)
+    
+    func nonAccelerometerMeasurable()
+    func nonGyroscopeMeasurable()
+    
+    func updateData(_ data: [Values])
+}

--- a/GyroData/Source/Domain/SensorMeasureService.swift
+++ b/GyroData/Source/Domain/SensorMeasureService.swift
@@ -2,10 +2,12 @@
 //  SensorMeasureService.swift
 //  GyroData
 //
-//  Created by 이정민 on 2023/02/01.
+//  Created by Kyo, JPush on 2023/02/01.
 //
 
+import CoreMotion
 import Foundation
+
 protocol MeasureDelegate: AnyObject {
     typealias Values = (x: Double, y: Double, z: Double)
     
@@ -13,4 +15,65 @@ protocol MeasureDelegate: AnyObject {
     func nonGyroscopeMeasurable()
     
     func updateData(_ data: [Values])
+}
+
+final class SensorMeasureService {
+    typealias Values = (x: Double, y: Double, z: Double)
+    
+    private var data: [Values] = [] {
+        didSet {
+            delegate?.updateData(data)
+        }
+    }
+    
+    private weak var delegate: MeasureDelegate?
+    private var timer: Timer = .init()
+    private let motionManager: CMMotionManager
+    
+    init(delegate: MeasureDelegate) {
+        self.delegate = delegate
+        self.motionManager = .init()
+    }
+    
+    func measureStart(_ sensorType: Sensor, interval: TimeInterval, duration: TimeInterval) {
+        data = .init()
+        
+        switch sensorType {
+        case .accelerometer:
+            accelerometerMeasureStart(interval, duration)
+        case .gyroscope:
+            gyroscopeMeasureStart(interval, duration)
+        }
+    }
+    
+    func measureStop() {
+        timer.invalidate()
+    }
+}
+
+private extension SensorMeasureService {
+    func accelerometerMeasureStart(_ interval: TimeInterval, _ duration: TimeInterval) {
+        guard motionManager.isAccelerometerAvailable else {
+            delegate?.nonAccelerometerMeasurable()
+            return
+        }
+        
+        motionManager.accelerometerUpdateInterval = interval
+        motionManager.startAccelerometerUpdates()
+        
+        timer = Timer(fire: Date(), interval: interval / duration, repeats: true) { timer in
+            if let data = self.motionManager.accelerometerData {
+                let accelerationData = (data.acceleration.x, data.acceleration.y, data.acceleration.z)
+                
+                self.data.append(accelerationData)
+            }
+        }
+        
+        RunLoop.current.add(timer, forMode: .common)
+    }
+    
+    
+    func gyroscopeMeasureStart(_ interval: TimeInterval, _ duration: TimeInterval) {
+        motionManager.gyroUpdateInterval = interval
+    }
 }


### PR DESCRIPTION
#15 

#### ⚙️ 작업내용
SensorMeasureService 구현
- accelerometer, gyroscope 에 따라 측정하는 메서드 구현
- 측정 중 측정을 중단할 수 있도록 measureStop() 메서드 구현 

#### 💡 참고사항
측정한 데이터를 저장하는 data타입을 배열 타입에서 기본 튜플 타입으로 변경했습니다.
배열전체의 값을 delegate로 넘기는 것보다 가장 최근에 측정된 값만 넘겨서 사용하는 곳에서 차곡차곡 쌓아 사용하는 것이 더 나을 것 같습니다.

`accelerometerMeasureStart(_ interval: TimeInterval, _ duration: TimeInterval)` 와 같은 식으로 interval과 duration을 받는데
외부변수를 받지 않는 함수형 프로그래밍을 위해서 간격, 총 시간을 받아 실행하도록 했습니다.

시뮬레이터에서 센서 테스트가 불가능 해서 실 기기에 설치해서 값 받아지는 것 확인했습니다.
단위테스트를 하고 싶었으나 measureStart() 에 대한 반환값이 없어서 테스트 하지 못했습니다.
어떻게 테스트 해야할까요....

#### ✅ 필수체크
- [x] 정상적인 빌드