### PR TITLE
13 feature measureviewmodel 구현

### DIFF
--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -45,8 +45,11 @@
 		AC52BB4329895C5C0057CA56 /* MeasureDataDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB4229895C5C0057CA56 /* MeasureDataDummy.swift */; };
 		AC52BB45298967B50057CA56 /* Sensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB44298967B50057CA56 /* Sensor.swift */; };
 		AC52BB46298967B50057CA56 /* Sensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB44298967B50057CA56 /* Sensor.swift */; };
-		AC52BB8B298B4D4B0057CA56 /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB8A298B4D4B0057CA56 /* GraphView.swift */; };
 		AC52BB49298A34070057CA56 /* SensorMeasureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB47298A34070057CA56 /* SensorMeasureService.swift */; };
+		AC52BB8B298B4D4B0057CA56 /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB8A298B4D4B0057CA56 /* GraphView.swift */; };
+		AC52BB8C298BAD000057CA56 /* SensorMeasureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB47298A34070057CA56 /* SensorMeasureService.swift */; };
+		AC52BB8E298BAD890057CA56 /* MeasureServiceDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB8D298BAD890057CA56 /* MeasureServiceDelegate.swift */; };
+		AC52BB91298BAE8C0057CA56 /* MeasureViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC52BB90298BAE8C0057CA56 /* MeasureViewDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,8 +93,10 @@
 		AC52BB3C298948E20057CA56 /* TransactionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionServiceTests.swift; sourceTree = "<group>"; };
 		AC52BB4229895C5C0057CA56 /* MeasureDataDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureDataDummy.swift; sourceTree = "<group>"; };
 		AC52BB44298967B50057CA56 /* Sensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sensor.swift; sourceTree = "<group>"; };
-		AC52BB8A298B4D4B0057CA56 /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
 		AC52BB47298A34070057CA56 /* SensorMeasureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMeasureService.swift; sourceTree = "<group>"; };
+		AC52BB8A298B4D4B0057CA56 /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
+		AC52BB8D298BAD890057CA56 /* MeasureServiceDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureServiceDelegate.swift; sourceTree = "<group>"; };
+		AC52BB90298BAE8C0057CA56 /* MeasureViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureViewDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +123,7 @@
 				3CB15C4329893DAE0049E390 /* DataManageable.swift */,
 				3CB15C4529893DC60049E390 /* FileManageable.swift */,
 				3CFD20D5298A3BAF00269FC9 /* Identifiable.swift */,
+				AC52BB8D298BAD890057CA56 /* MeasureServiceDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -125,6 +131,7 @@
 		3CB15C47298944D40049E390 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				AC52BB8F298BAE720057CA56 /* Protocol */,
 				AC52BB88298B4D2E0057CA56 /* Common */,
 				3CB15C48298944F10049E390 /* DataListScene */,
 				3CB15C4D298945790049E390 /* MeasureScene */,
@@ -334,6 +341,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		AC52BB8F298BAE720057CA56 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				AC52BB90298BAE8C0057CA56 /* MeasureViewDelegate.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -440,11 +455,14 @@
 				AC52BB8B298B4D4B0057CA56 /* GraphView.swift in Sources */,
 				3CB15C4429893DAE0049E390 /* DataManageable.swift in Sources */,
 				63F01BB528D44FC400C53A39 /* AppDelegate.swift in Sources */,
+				AC52BB8E298BAD890057CA56 /* MeasureServiceDelegate.swift in Sources */,
 				63F01BB728D44FC400C53A39 /* SceneDelegate.swift in Sources */,
+				AC52BB91298BAE8C0057CA56 /* MeasureViewDelegate.swift in Sources */,
 				3CB15C4C2989456E0049E390 /* DataListViewModel.swift in Sources */,
 				AC52BAC52987F91A0057CA56 /* SensorData+CoreDataProperties.swift in Sources */,
 				3CFD20D9298A5F6A00269FC9 /* UIComponent+Extension.swift in Sources */,
 				AC52BAAE2987E9C60057CA56 /* TransactionService.swift in Sources */,
+				AC52BB8C298BAD000057CA56 /* SensorMeasureService.swift in Sources */,
 				3CB15C4629893DC60049E390 /* FileManageable.swift in Sources */,
 				AC52BAC42987F91A0057CA56 /* SensorData+CoreDataClass.swift in Sources */,
 				AC52BAB22987EA180057CA56 /* CoreDataManager.swift in Sources */,
@@ -452,7 +470,6 @@
 				AC52BAB42987EA2A0057CA56 /* FileSystemManager.swift in Sources */,
 				3CFD20D6298A3BAF00269FC9 /* Identifiable.swift in Sources */,
 				3CB15C4A298945620049E390 /* DataListViewController.swift in Sources */,
-				AC52BB48298A34070057CA56 /* SensorMeasureService.swift in Sources */,
 				AC52BAC12987F8BA0057CA56 /* SensorData.xcdatamodeld in Sources */,
 				3CB15C4F298945D50049E390 /* MeasureViewController.swift in Sources */,
 				3CB15C51298945E40049E390 /* MeasureViewModel.swift in Sources */,

--- a/GyroData/Source/Domain/Entities/MeasureData.swift
+++ b/GyroData/Source/Domain/Entities/MeasureData.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct MeasureData: Codable, Hashable {
-    let xValue: [Double]
-    let yValue: [Double]
-    let zValue: [Double]
+    var xValue: [Double]
+    var yValue: [Double]
+    var zValue: [Double]
     let runTime: Double
     let date: Date
-    let type: Sensor?
+    var type: Sensor?
 }

--- a/GyroData/Source/Domain/Entities/MeasureData.swift
+++ b/GyroData/Source/Domain/Entities/MeasureData.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct MeasureData: Codable, Hashable {
-    var xValue: [Double]
-    var yValue: [Double]
-    var zValue: [Double]
+    let xValue: [Double]
+    let yValue: [Double]
+    let zValue: [Double]
     let runTime: Double
     let date: Date
-    var type: Sensor?
+    let type: Sensor?
 }

--- a/GyroData/Source/Domain/Protocol/MeasureServiceDelegate.swift
+++ b/GyroData/Source/Domain/Protocol/MeasureServiceDelegate.swift
@@ -14,6 +14,5 @@ protocol MeasureServiceDelegate: AnyObject {
     func nonGyroscopeMeasurable()
     
     func updateData(_ data: Values)
-    func endMeasuringData()
-    func emitWasteTime(_ wasteTime: TimeInterval)
+    func endMeasuringData(_ wasteTime: TimeInterval)
 }

--- a/GyroData/Source/Domain/Protocol/MeasureServiceDelegate.swift
+++ b/GyroData/Source/Domain/Protocol/MeasureServiceDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  MeasureServiceDelegate.swift
+//  GyroData
+//
+//  Created by 이정민 on 2023/02/02.
+//
+
+import Foundation
+
+protocol MeasureServiceDelegate: AnyObject {
+    typealias Values = (x: Double, y: Double, z: Double)
+    
+    func nonAccelerometerMeasurable()
+    func nonGyroscopeMeasurable()
+    
+    func updateData(_ data: Values)
+    func endMeasuringData()
+}

--- a/GyroData/Source/Domain/Protocol/MeasureServiceDelegate.swift
+++ b/GyroData/Source/Domain/Protocol/MeasureServiceDelegate.swift
@@ -15,4 +15,5 @@ protocol MeasureServiceDelegate: AnyObject {
     
     func updateData(_ data: Values)
     func endMeasuringData()
+    func emitWasteTime(_ wasteTime: TimeInterval)
 }

--- a/GyroData/Source/Domain/SensorMeasureService.swift
+++ b/GyroData/Source/Domain/SensorMeasureService.swift
@@ -67,7 +67,14 @@ private extension SensorMeasureService {
     }
     
     func isTimeOver(_ duration: TimeInterval, from fireDate: Date) -> Bool {
-        return Date().timeIntervalSince(fireDate) > duration ? true : false
+        let wasteTime = Date().timeIntervalSince(fireDate)
+
+        if wasteTime > duration {
+            delegate?.emitWasteTime(wasteTime)
+            return true
+        } else {
+            return false
+        }
     }
     
     func gyroscopeMeasureStart(_ interval: TimeInterval, _ duration: TimeInterval) {

--- a/GyroData/Source/Domain/SensorMeasureService.swift
+++ b/GyroData/Source/Domain/SensorMeasureService.swift
@@ -17,15 +17,10 @@ final class SensorMeasureService {
         }
     }
     
-    private weak var delegate: MeasureServiceDelegate?
     private var timer: Timer = .init()
-    private let motionManager: CMMotionManager
+    private let motionManager: CMMotionManager = .init()
     private var fireDate: Date = Date()
-    
-    init(delegate: MeasureServiceDelegate) {
-        self.delegate = delegate
-        self.motionManager = .init()
-    }
+    weak var delegate: MeasureServiceDelegate?
     
     func measureStart(_ sensorType: Sensor, interval: TimeInterval, duration: TimeInterval) {
         switch sensorType {

--- a/GyroData/Source/Domain/SensorMeasureService.swift
+++ b/GyroData/Source/Domain/SensorMeasureService.swift
@@ -8,16 +8,6 @@
 import CoreMotion
 import Foundation
 
-protocol MeasureDelegate: AnyObject {
-    typealias Values = (x: Double, y: Double, z: Double)
-    
-    func nonAccelerometerMeasurable()
-    func nonGyroscopeMeasurable()
-    
-    func updateData(_ data: Values)
-    func endMeasuringData()
-}
-
 final class SensorMeasureService {
     typealias Values = (x: Double, y: Double, z: Double)
     
@@ -27,11 +17,11 @@ final class SensorMeasureService {
         }
     }
     
-    private weak var delegate: MeasureDelegate?
+    private weak var delegate: MeasureServiceDelegate?
     private var timer: Timer = .init()
     private let motionManager: CMMotionManager
     
-    init(delegate: MeasureDelegate) {
+    init(delegate: MeasureServiceDelegate) {
         self.delegate = delegate
         self.motionManager = .init()
     }

--- a/GyroData/Source/Presentation/Common/Views/GraphView.swift
+++ b/GyroData/Source/Presentation/Common/Views/GraphView.swift
@@ -190,7 +190,7 @@ private extension GraphView {
     func mappingValuesToFrame(values: Values) -> Values {
         let mappingValues = [values.x, values.y, values.z].map {
             let mappingValue = $0 / (boundary * 2)
-            let positionFromFrame = (self.frame.height / 2.0) - mappingValue
+            let positionFromFrame = self.frame.height * (0.5 - mappingValue)
             
             return positionFromFrame
         }

--- a/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
+++ b/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
@@ -37,6 +37,7 @@ class MeasureViewModel {
     init(delegate: MeasureViewDelegate, measureService: SensorMeasureService) {
         self.delegate = delegate
         self.measureService = measureService
+        self.measureData = MeasureData()
     }
     
     func action(_ action: Action) {

--- a/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
+++ b/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
@@ -11,9 +11,10 @@ class MeasureViewModel {
     typealias Values = (x: Double, y: Double, z: Double)
     
     enum Action {
-        case mesureStartButtonTapped(sensorType: Sensor)
+        case mesureStartButtonTapped
         case measureEndbuttonTapped
         case saveButtonTapped
+        case sensorTypeChanged(sensorType: Sensor?)
     }
     
     private var sensorMeasureValues: Values = (0, 0, 0) {
@@ -44,13 +45,16 @@ class MeasureViewModel {
     
     func action(_ action: Action) {
         switch action {
-        case .mesureStartButtonTapped(sensorType: let sensorType):
+        case .mesureStartButtonTapped:
+            guard let sensorType = sensorType else { return }
             startDate = Date()
             measureService.measureStart(sensorType, interval: 0.1, duration: 60)
         case .measureEndbuttonTapped:
             measureService.measureStop()
         case .saveButtonTapped:
             saveMeasureData()
+        case .sensorTypeChanged(sensorType: let sensorType):
+            self.sensorType = sensorType
         }
     }
 }

--- a/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
+++ b/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
@@ -6,3 +6,81 @@
 //
 
 import Foundation
+
+class MeasureViewModel {
+    typealias Values = (x: Double, y: Double, z: Double)
+    
+    enum Action {
+        case mesureStartButtonTapped(sensorType: Sensor)
+        case measureEndbuttonTapped
+        case saveButtonTapped
+    }
+    
+    private var measureData: MeasureData {
+        didSet {
+            if let xValue = measureData.xValue.last,
+               let yValue = measureData.yValue.last,
+               let zValue = measureData.zValue.last {
+                
+                let lastData: Values = (xValue, yValue, zValue)
+                delegate?.updateValue(lastData)
+            }
+        }
+    }
+    private let transactionSevice = TransactionService(
+        coreDataManager: CoreDataManager(),
+        fileManager: FileSystemManager()
+    )
+    private let measureService: SensorMeasureService
+    private weak var delegate: MeasureViewDelegate?
+    
+    init(delegate: MeasureViewDelegate, measureService: SensorMeasureService) {
+        self.delegate = delegate
+        self.measureService = measureService
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case .mesureStartButtonTapped(sensorType: let sensorType):
+            measureService.measureStart(sensorType, interval: 0.1, duration: 60)
+        case .measureEndbuttonTapped:
+            measureService.measureStop()
+        case .saveButtonTapped:
+            saveMeasureData()
+        }
+    }
+}
+
+private extension MeasureViewModel {
+    func saveMeasureData() {
+        transactionSevice.save(data: measureData) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(_):
+                self.delegate?.saveSuccess()
+            case .failure(let error):
+                self.delegate?.saveFail(error)
+            }
+        }
+    }
+}
+
+extension MeasureViewModel: MeasureServiceDelegate {
+    func nonAccelerometerMeasurable() {
+        delegate?.nonAccelerometerMeasurable()
+    }
+    
+    func nonGyroscopeMeasurable() {
+        delegate?.nonGyroscopeMeasurable()
+    }
+    
+    func updateData(_ data: Values) {
+        self.measureData.xValue.append(data.x)
+        self.measureData.yValue.append(data.y)
+        self.measureData.zValue.append(data.z)
+    }
+    
+    func endMeasuringData() {
+        delegate?.endMeasuringData()
+    }
+}

--- a/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
+++ b/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
@@ -98,11 +98,8 @@ extension MeasureViewModel: MeasureServiceDelegate {
         sensorMeasureValues = data
     }
     
-    func endMeasuringData() {
-        delegate?.endMeasuringData()
-    }
-    
-    func emitWasteTime(_ wasteTime: TimeInterval) {
+    func endMeasuringData(_ wasteTime: TimeInterval) {
         self.wasteTime = wasteTime
+        delegate?.endMeasuringData()
     }
 }

--- a/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
+++ b/GyroData/Source/Presentation/MeasureScene/MeasureViewModel.swift
@@ -36,10 +36,9 @@ class MeasureViewModel {
     )
     private let measureService: SensorMeasureService
     
-    private weak var delegate: MeasureViewDelegate?
+    weak var delegate: MeasureViewDelegate?
     
-    init(delegate: MeasureViewDelegate, measureService: SensorMeasureService) {
-        self.delegate = delegate
+    init(measureService: SensorMeasureService) {
         self.measureService = measureService
     }
     

--- a/GyroData/Source/Presentation/Protocol/MeasureViewDelegate.swift
+++ b/GyroData/Source/Presentation/Protocol/MeasureViewDelegate.swift
@@ -1,0 +1,20 @@
+//
+//  MeasureViewDelegate.swift
+//  GyroData
+//
+//  Created by 이정민 on 2023/02/02.
+//
+
+import Foundation
+
+protocol MeasureViewDelegate: AnyObject {
+    typealias Values = (x: Double, y: Double, z: Double)
+    
+    func updateValue(_ values: Values)
+    func nonAccelerometerMeasurable()
+    func nonGyroscopeMeasurable()
+    func endMeasuringData()
+    
+    func saveSuccess()
+    func saveFail(_ error: Error)
+}


### PR DESCRIPTION
### ⚙️ 작업내용
measureViewModel 구현

- input
측정시작 버튼 탭
측정중지 버튼 탭
저장 버튼 탭
세그먼트 컨트롤 스위칭

- output
측정이 시작되었을 때 반환되는 센서 값
측정이 중지되었을 때 반환되는 소요시간 값
가속도 센서를 사용할 수 없을 때 알림
자이로 센서를 사용할 수 없을 때 알림

### 💡참고사항 
**init 시 delegate와 service를 주입받아 사용.**

호출하는 곳에서 객체를 생성하여 보내는데 사용하는 곳인 Viewcontroller에서 생성해서 푸시하게 될 것 같습니다
viewModel 생성시 viewController를 delegate로 할당하고
viewModel 생성시 service를 주입받아 사용하는데
service를 생성할 때 delegate로 viewModel을 할당해주어야 해서 생성시점이 맞지 않아 외부에서 할당해 주도록 해야할 것 같습니다

#### ❎ before
<img width="1044" alt="스크린샷 2023-02-02 20 22 44" src="https://user-images.githubusercontent.com/82566116/216311817-16f51cf0-22a0-416c-9c0f-6ee414d8b17b.png">

#### ✅ after
<img width="877" alt="스크린샷 2023-02-02 20 25 58" src="https://user-images.githubusercontent.com/82566116/216312600-dce4a314-f8a9-4195-bef2-1ad98242516b.png">

하지만 이러면 단점이 viewController에서 service 객체를 만들어서 사용을 하게 되는데 viewcontroller에서 service를 알게되는 것이 클린아키텍쳐 상 옳지 않아보입니다... 

이를 해결하려면 coordinator 패턴을 사용해야될 것 같은데 이번 프로젝트에서는 사용하지 않기로 했으니 이정도는 애교로 넘어가야할 것 같습니다

---

**model타입을 가지지 않고 요소를 각각 가짐**

MeasureData 타입을 가지고 센서에서 값이 들어올 때 수정해주려 했으나
runtime Date 등이 바뀔 때도 didset이 작동해서 각 요소를 분리했습니다

이후 코어데이터에 저장할 때 모델을 만들어 주는데 그 때 만들어 사용하는 것으로 했습니다.
계층 관계상 이것이 더 나아보여서 이걸로 하는게 나을 것 같습니다

### ✅ 필수체크
- [x] 정상적인 빌드
