### PR TITLE
refactor : DataListViewModel에서 ViewController의 액션을 하나의 메서드에서 처리하도록 변경

### DIFF
--- a/GyroData/Source/Presentation/DataListScene/DataListViewController.swift
+++ b/GyroData/Source/Presentation/DataListScene/DataListViewController.swift
@@ -10,6 +10,9 @@ import UIKit
 protocol DataListConfigurable: AnyObject {
     func setupData(_ datas: [MeasureData])
     func setupSelectData(_ data: MeasureData)
+    func setupMeasure()
+    func setupPlay()
+    func setupDelete()
 }
 
 final class DataListViewController: UIViewController {
@@ -49,11 +52,30 @@ extension DataListViewController: DataListConfigurable {
             animated: true
         )
     }
+    
+    func setupMeasure() {
+        navigationController?.pushViewController(MeasureViewController(), animated: true)
+    }
+    
+    func setupPlay() {
+        //TODO: Move to Play View
+    }
+    
+    func setupDelete() {
+        //TODO: Data Delete
+    }
+}
+
+// MARK: - Action
+extension DataListViewController {
+    @objc private func measureButtonTapped() {
+        viewModel.action(.measure)
+    }
 }
 
 extension DataListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        viewModel.fetchSelectedData(index: indexPath.row)
+        viewModel.action(.cellSelect(index: indexPath.row))
     }
 }
 
@@ -94,6 +116,15 @@ extension DataListViewController {
         tableView.delegate = self
         navigationController?.navigationBar.standardAppearance = appearance
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        
+        let measureBarButton = UIBarButtonItem(
+            title: "측정",
+            style: .plain,
+            target: self,
+            action: #selector(measureButtonTapped)
+        )
+        
+        navigationItem.rightBarButtonItem = measureBarButton
     }
     
     private func setupView() {

--- a/GyroData/Source/Presentation/DataListScene/DataListViewModel.swift
+++ b/GyroData/Source/Presentation/DataListScene/DataListViewModel.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 final class DataListViewModel {
+    enum Action {
+        case cellSelect(index: Int)
+        case measure
+        case play
+        case delete
+    }
+    
     private let transactionSevice = TransactionService(
         coreDataManager: CoreDataManager(),
         fileManager: FileSystemManager()
@@ -35,7 +42,16 @@ extension DataListViewModel {
         }
     }
     
-    func fetchSelectedData(index: Int) {
-        delegate?.setupSelectData(measureDatas[index])
+    func action(_ action: Action) {
+        switch action {
+        case .cellSelect(let index):
+            delegate?.setupSelectData(measureDatas[index])
+        case .measure:
+            delegate?.setupMeasure()
+        case .play:
+            delegate?.setupPlay()
+        case .delete:
+            delegate?.setupDelete()
+        }
     }
 }


### PR DESCRIPTION
- DataListViewModel에서 ViewController에 대한 이벤트 처리를 action 메서드에서 분기로 처리하도록 변경
- DataListConfigurable 프로토콜 setupMeasure(),setupPlay(), setupDelete() 추가
- MeasureViewController 생성시 ViewModel 주입한다면 수정 필요