### PR TITLE
35 feature 재사용 가능한 alert controller 생성

### DIFF
--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C81E3B2298CDDC500B5BC59 /* AlertBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C81E3B1298CDDC500B5BC59 /* AlertBuilder.swift */; };
+		3C81E3B4298CE07100B5BC59 /* ErrorAlertBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C81E3B3298CE07100B5BC59 /* ErrorAlertBuilder.swift */; };
+		3C81E3B7298CE09F00B5BC59 /* AlertDirector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C81E3B6298CE09F00B5BC59 /* AlertDirector.swift */; };
 		3CB15C4429893DAE0049E390 /* DataManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB15C4329893DAE0049E390 /* DataManageable.swift */; };
 		3CB15C4629893DC60049E390 /* FileManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB15C4529893DC60049E390 /* FileManageable.swift */; };
 		3CB15C4A298945620049E390 /* DataListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB15C49298945620049E390 /* DataListViewController.swift */; };
@@ -65,6 +68,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3C81E3B1298CDDC500B5BC59 /* AlertBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertBuilder.swift; sourceTree = "<group>"; };
+		3C81E3B3298CE07100B5BC59 /* ErrorAlertBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlertBuilder.swift; sourceTree = "<group>"; };
+		3C81E3B6298CE09F00B5BC59 /* AlertDirector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDirector.swift; sourceTree = "<group>"; };
 		3CB15C4329893DAE0049E390 /* DataManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManageable.swift; sourceTree = "<group>"; };
 		3CB15C4529893DC60049E390 /* FileManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManageable.swift; sourceTree = "<group>"; };
 		3CB15C49298945620049E390 /* DataListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataListViewController.swift; sourceTree = "<group>"; };
@@ -121,6 +127,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3C81E3B0298CDDB100B5BC59 /* Builder */ = {
+			isa = PBXGroup;
+			children = (
+				3C81E3B1298CDDC500B5BC59 /* AlertBuilder.swift */,
+				3C81E3B3298CE07100B5BC59 /* ErrorAlertBuilder.swift */,
+			);
+			path = Builder;
+			sourceTree = "<group>";
+		};
+		3C81E3B5298CE09100B5BC59 /* Director */ = {
+			isa = PBXGroup;
+			children = (
+				3C81E3B6298CE09F00B5BC59 /* AlertDirector.swift */,
+			);
+			path = Director;
+			sourceTree = "<group>";
+		};
 		3CB15C4229893D9B0049E390 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
@@ -250,6 +273,8 @@
 		AC52BAC629880B660057CA56 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				3C81E3B5298CE09100B5BC59 /* Director */,
+				3C81E3B0298CDDB100B5BC59 /* Builder */,
 				3CFD20D7298A5F5A00269FC9 /* Extension */,
 				AC52BAEE2988D45C0057CA56 /* Error */,
 			);
@@ -477,6 +502,8 @@
 				AC52BAC52987F91A0057CA56 /* SensorData+CoreDataProperties.swift in Sources */,
 				3CFD20D9298A5F6A00269FC9 /* UIComponent+Extension.swift in Sources */,
 				AC52BAAE2987E9C60057CA56 /* TransactionService.swift in Sources */,
+				3C81E3B4298CE07100B5BC59 /* ErrorAlertBuilder.swift in Sources */,
+				3C81E3B7298CE09F00B5BC59 /* AlertDirector.swift in Sources */,
 				3CB15C4629893DC60049E390 /* FileManageable.swift in Sources */,
 				3CFD20DC298BCD6000269FC9 /* DetailViewModel.swift in Sources */,
 				AC52BAC42987F91A0057CA56 /* SensorData+CoreDataClass.swift in Sources */,
@@ -484,6 +511,7 @@
 				AC52BAAC2987E9930057CA56 /* MeasureData.swift in Sources */,
 				3CFD20E0298BCEDE00269FC9 /* DetailViewController.swift in Sources */,
 				AC52BAB42987EA2A0057CA56 /* FileSystemManager.swift in Sources */,
+				3C81E3B2298CDDC500B5BC59 /* AlertBuilder.swift in Sources */,
 				3CFD20D6298A3BAF00269FC9 /* Identifiable.swift in Sources */,
 				3CB15C4A298945620049E390 /* DataListViewController.swift in Sources */,
 				AC52BAC12987F8BA0057CA56 /* SensorData.xcdatamodeld in Sources */,

--- a/GyroData/Source/Common/Builder/AlertBuilder.swift
+++ b/GyroData/Source/Common/Builder/AlertBuilder.swift
@@ -1,0 +1,20 @@
+//
+//  AlertBuilder.swift
+//  GyroData
+//
+//  Created by parkhyo on 2023/02/03.
+//
+
+import UIKit
+
+protocol AlertBuilder {
+    var alert: UIAlertController { get }
+    func setTitle(_ title: String) -> AlertBuilder
+    func setMessage(_ message: String) -> AlertBuilder
+    func setAction(
+        title: String,
+        style: UIAlertAction.Style,
+        handler: ((UIAlertAction) -> Void)?
+    ) -> AlertBuilder
+    func makeAlert() -> UIAlertController
+}

--- a/GyroData/Source/Common/Builder/ErrorAlertBuilder.swift
+++ b/GyroData/Source/Common/Builder/ErrorAlertBuilder.swift
@@ -1,0 +1,35 @@
+//
+//  ErrorAlertBuilder.swift
+//  GyroData
+//
+//  Created by parkhyo on 2023/02/03.
+//
+
+import UIKit
+
+final class ErrorAlertBuilder: AlertBuilder {
+    var alert =  UIAlertController()
+    
+    func setTitle(_ title: String) -> AlertBuilder {
+        alert.title = title
+        return self
+    }
+    
+    func setMessage(_ message: String) -> AlertBuilder {
+        alert.message = message
+        return self
+    }
+    
+    func setAction(
+        title: String,
+        style: UIAlertAction.Style,
+        handler: ((UIAlertAction) -> Void)?
+    ) -> AlertBuilder {
+        alert.addAction(UIAlertAction(title: title, style: style, handler: handler))
+        return self
+    }
+    
+    func makeAlert() -> UIAlertController {
+        return alert
+    }
+}

--- a/GyroData/Source/Common/Builder/ErrorAlertBuilder.swift
+++ b/GyroData/Source/Common/Builder/ErrorAlertBuilder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class ErrorAlertBuilder: AlertBuilder {
-    var alert =  UIAlertController()
+    var alert =  UIAlertController(title: nil, message: nil, preferredStyle: .alert)
     
     func setTitle(_ title: String) -> AlertBuilder {
         alert.title = title

--- a/GyroData/Source/Common/Director/AlertDirector.swift
+++ b/GyroData/Source/Common/Director/AlertDirector.swift
@@ -1,0 +1,20 @@
+//
+//  AlertDirector.swift
+//  GyroData
+//
+//  Created by parkhyo on 2023/02/03.
+//
+
+import UIKit
+
+final class AlertDirector {
+    func setupErrorAlert(builder: AlertBuilder, errorMessage: String) -> UIAlertController {
+        let alert = builder
+            .setTitle("오류")
+            .setMessage(errorMessage)
+            .setAction(title: "취소", style: .cancel, handler: nil)
+            .makeAlert()
+            
+        return alert
+    }
+}

--- a/GyroData/Source/Common/Error/FileSystemError.swift
+++ b/GyroData/Source/Common/Error/FileSystemError.swift
@@ -14,3 +14,20 @@ enum FileSystemError: Error {
     case deleteError
     case unknownError
 }
+
+extension FileSystemError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .encodeError:
+            return "인코딩 오류입니다."
+        case .saveError:
+            return "저장 실패하였습니다."
+        case .loadError:
+            return "데이터 불러오기 실패하였습니다."
+        case .deleteError:
+            return "삭제 실패하였습니다."
+        case .unknownError:
+            return "오류 발생하였습니다."
+        }
+    }
+}

--- a/GyroData/Source/Domain/TransactionService.swift
+++ b/GyroData/Source/Domain/TransactionService.swift
@@ -78,7 +78,9 @@ extension TransactionService {
             do {
                 try self.coreDataManager.delete(date)
             } catch {
-                return completion(.failure(error))
+                DispatchQueue.main.async {
+                    return completion(.failure(error))
+                }
             }
         }
         
@@ -86,7 +88,9 @@ extension TransactionService {
             do {
                 try self.fileManager.delete(date)
             } catch {
-                return completion(.failure(error))
+                DispatchQueue.main.async {
+                    return completion(.failure(error))
+                }
             }
         }
         

--- a/GyroData/Source/Presentation/DataListScene/DataListViewController.swift
+++ b/GyroData/Source/Presentation/DataListScene/DataListViewController.swift
@@ -32,7 +32,7 @@ final class DataListViewController: UIViewController {
     
     private let tableView = UITableView(frame: .zero, style: .plain)
     
-    private lazy var viewModel = DataListViewModel(delegate: self)
+    private lazy var viewModel = DataListViewModel(delegate: self, alertDelegate: self)
     private lazy var dataSource = configureDataSoruce()
     
     override func viewDidLoad() {

--- a/GyroData/Source/Presentation/DataListScene/DataListViewController.swift
+++ b/GyroData/Source/Presentation/DataListScene/DataListViewController.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol AlertPresentable: AnyObject {
+    func presentErrorAlert(message: String)
+}
+
 protocol DataListConfigurable: AnyObject {
     func setupData(_ datas: [MeasureData])
     func setupSelectData(_ data: MeasureData)
@@ -39,7 +43,7 @@ final class DataListViewController: UIViewController {
     }
 }
 
-// MARK: - DataListConfigurable
+// MARK: - DataListConfigurable Protocol
 extension DataListViewController: DataListConfigurable {
     func setupData(_ datas: [MeasureData]) {
         applySnapshot(datas: datas, true)
@@ -58,6 +62,17 @@ extension DataListViewController: DataListConfigurable {
     
     func setupPlay(_ data: MeasureData) {
         //TODO: Move to Play View
+    }
+}
+
+// MARK: - AlertPresentable Protocol
+extension DataListViewController: AlertPresentable {
+    func presentErrorAlert(message: String) {
+        let errorAlert = AlertDirector().setupErrorAlert(
+            builder: ErrorAlertBuilder(),
+            errorMessage: message
+        )
+        present(errorAlert, animated: true)
     }
 }
 


### PR DESCRIPTION
Builder 패턴을 사용해서 Alert 구현

- 현재 ErrorAlertBuilder 만 구현
- 기기의 센서를 사용하지 못하면 SensorAlertBuilder 구현하여 Alert Present 필요
- FileSystemError ErrorDescription 추가 
- AlertPresentable Delegate 프로토콜 추가
- TransactionService의 Delete 메서드 : global Thread 동작중 에러발생시 MainThread로 이동하여 return 하도록 변경

![](https://i.imgur.com/aBEtlRF.png)