### PR TITLE
39 reafactor 기존 alert을 alertbuilder 사용하여 개선

### DIFF
--- a/GyroData/Source/Common/Director/AlertDirector.swift
+++ b/GyroData/Source/Common/Director/AlertDirector.swift
@@ -8,11 +8,11 @@
 import UIKit
 
 final class AlertDirector {
-    func setupErrorAlert(builder: AlertBuilder, errorMessage: String) -> UIAlertController {
+    func setupErrorAlert(builder: AlertBuilder, title: String, errorMessage: String) -> UIAlertController {
         let alert = builder
-            .setTitle("오류")
+            .setTitle(title)
             .setMessage(errorMessage)
-            .setAction(title: "취소", style: .cancel, handler: nil)
+            .setAction(title: "확인", style: .default, handler: nil)
             .makeAlert()
             
         return alert

--- a/GyroData/Source/Presentation/DataListScene/DataListViewController.swift
+++ b/GyroData/Source/Presentation/DataListScene/DataListViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol AlertPresentable: AnyObject {
-    func presentErrorAlert(message: String)
+    func presentErrorAlert(title: String, message: String)
 }
 
 protocol DataListConfigurable: AnyObject {
@@ -69,9 +69,10 @@ extension DataListViewController: DataListConfigurable {
 
 // MARK: - AlertPresentable Protocol
 extension DataListViewController: AlertPresentable {
-    func presentErrorAlert(message: String) {
+    func presentErrorAlert(title: String, message: String) {
         let errorAlert = AlertDirector().setupErrorAlert(
             builder: ErrorAlertBuilder(),
+            title: title,
             errorMessage: message
         )
         present(errorAlert, animated: true)

--- a/GyroData/Source/Presentation/DataListScene/DataListViewModel.swift
+++ b/GyroData/Source/Presentation/DataListScene/DataListViewModel.swift
@@ -64,13 +64,22 @@ extension DataListViewModel {
                 return
             case .failure(let error):
                 if let coreDataError = error as? CoreDataError {
-                    self?.alertDelegate?.presentErrorAlert(message: coreDataError.errorDescription ?? "")
+                    self?.alertDelegate?.presentErrorAlert(
+                        title: "오류발생",
+                        message: coreDataError.errorDescription ?? ""
+                    )
                     return
                 } else if let fileError = error as? FileSystemError {
-                    self?.alertDelegate?.presentErrorAlert(message: fileError.errorDescription ?? "")
+                    self?.alertDelegate?.presentErrorAlert(
+                        title: "오류발생",
+                        message: fileError.errorDescription ?? ""
+                    )
                     return
                 }
-                self?.alertDelegate?.presentErrorAlert(message: error.localizedDescription)
+                self?.alertDelegate?.presentErrorAlert(
+                    title: "오류발생",
+                    message: error.localizedDescription
+                )
             }
         }
     }

--- a/GyroData/Source/Presentation/MeasureScene/MeasureViewController.swift
+++ b/GyroData/Source/Presentation/MeasureScene/MeasureViewController.swift
@@ -92,6 +92,7 @@ class MeasureViewController: UIViewController {
 private extension MeasureViewController {
     func setViewModelDelegate() {
         self.viewModel.delegate = self
+        self.viewModel.alertDelegate = self
     }
     
     func setupNavigationBar() {
@@ -198,38 +199,6 @@ extension MeasureViewController: MeasureViewDelegate {
         graphView.setNeedsDisplay()
     }
     
-    func nonAccelerometerMeasurable() {
-        let alertController = UIAlertController(
-            title: "센서 에러",
-            message: "가속도 센서 사용 불가",
-            preferredStyle: .alert
-        )
-        let defaultAction = UIAlertAction(
-            title: Constant.saveFailAlertActionTitle,
-            style: .default
-        )
-        
-        alertController.addAction(defaultAction)
-        
-        present(alertController, animated: true)
-    }
-    
-    func nonGyroscopeMeasurable() {
-        let alertController = UIAlertController(
-            title: "센서 에러",
-            message: "자이로 센서 사용 불가",
-            preferredStyle: .alert
-        )
-        let defaultAction = UIAlertAction(
-            title: Constant.saveFailAlertActionTitle,
-            style: .default
-        )
-        
-        alertController.addAction(defaultAction)
-        
-        present(alertController, animated: true)
-    }
-    
     func endMeasuringData() {
         setUserInteractive(true)
     }
@@ -241,20 +210,19 @@ extension MeasureViewController: MeasureViewDelegate {
     
     func saveFail(_ error: Error) {
         activityIndicatorView.stopAnimating()
-        let alertController = UIAlertController(
-            title: Constant.saveFailAlertTitle,
-            message: error.localizedDescription,
-            preferredStyle: .alert
-        )
-        let defaultAction = UIAlertAction(
-            title: Constant.saveFailAlertActionTitle,
-            style: .default
-        )
-        
-        alertController.addAction(defaultAction)
-        
-        present(alertController, animated: true)
     }
+}
+
+extension MeasureViewController: AlertPresentable {
+    func presentErrorAlert(title: String, message: String) {
+        let errorAlert = AlertDirector().setupErrorAlert(
+            builder: ErrorAlertBuilder(),
+            title: title,
+            errorMessage: message
+        )
+        present(errorAlert, animated: true)
+    }
+
 }
 
 //import SwiftUI

--- a/GyroData/Source/Presentation/Protocol/MeasureViewDelegate.swift
+++ b/GyroData/Source/Presentation/Protocol/MeasureViewDelegate.swift
@@ -11,8 +11,6 @@ protocol MeasureViewDelegate: AnyObject {
     typealias Values = (x: Double, y: Double, z: Double)
     
     func updateValue(_ values: Values)
-    func nonAccelerometerMeasurable()
-    func nonGyroscopeMeasurable()
     func endMeasuringData()
     
     func saveSuccess()


### PR DESCRIPTION
기존 Alert을 alertbuilder 사용하여 개선

- AlertDirector().setupErrorAlert()의 인자로 message 뿐만 아니라 title도 받을 수 있도록 추가
- 자이로센서, 가속도센서 사용 불가시 Alert 띄우는 로직을 Alert 전용 Delegate와 AlertDirector 통해서 띄우는 방식으로 변경
- 기존의 MeasureViewDelegate 프로토콜의 얼럿을 위한 메서드 삭제
